### PR TITLE
Bug 1467877 - add jsone_templates that parses multiple YAML docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,34 @@ of `jsonencode` will be your best bet.
 You can access the rendered template with `.rendered` much the same as with `template_file`. This will normally
 be in `json` format unless you explicitely pass in `format = "yaml"` to the resource.
 
+### Multiple Templates
+
+In some cases, it is useful to have multiple templates in the input file.
+In this case, the `rendered` value is a list of JSON- (or YAML-) formatted rendered templates.
+Use the `jsone_templates` resource (note the plural) for this purpose.
+
+```yaml
+# service.yaml
+---
+one: '{$eval: "17 - 16"}'
+---
+two: '{$eval: "12 / 6"}'
+```
+
+```terraform
+data "jsone_templates" "service" {
+  template = "${file("${path.module}/service.yaml")}"
+  yaml_context = "${jsonencode(local.context)}"
+}
+
+output "rendered" {
+  value1 = "${data.jsone_template.service.rendered[0]}"
+  # --> '{"one": 1}'
+  value2 = "${data.jsone_template.service.rendered[1]}"
+  # --> '{"two": 2}'
+}
+```
+
 # Development
 
 Go requirements are the same as Terraform itself (currently 1.9).

--- a/jsoneprovider/provider.go
+++ b/jsoneprovider/provider.go
@@ -8,7 +8,8 @@ import (
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		DataSourcesMap: map[string]*schema.Resource{
-			"jsone_template": dataSourceJsoneTemplate(),
+			"jsone_template":  dataSourceJsoneTemplate(),
+			"jsone_templates": dataSourceJsoneTemplates(),
 		},
 	}
 }

--- a/yaml/decoder.go
+++ b/yaml/decoder.go
@@ -1,0 +1,46 @@
+// Extend https://github.com/ghodss/yaml to be able to handle multi-document
+// streams.  This uses go-yaml to parse the stream, then converts back to YAML
+// and feeds the result to ghodss/yaml, which unmarshals it, converts it to
+// JSON, and then unmarshals that into a data structure
+
+package yaml
+
+import (
+	"io"
+
+	ghodssYaml "github.com/ghodss/yaml"
+	goYaml "gopkg.in/yaml.v2"
+)
+
+type Decoder struct {
+	decoder *goYaml.Decoder
+}
+
+func NewDecoder(r io.Reader) *Decoder {
+	return &Decoder{
+		decoder: goYaml.NewDecoder(r),
+	}
+}
+
+func (dec *Decoder) Decode(result interface{}) (err error) {
+	var singleValue interface{}
+
+	// decode a single document from the stream
+	if err := dec.decoder.Decode(&singleValue); err != nil {
+		return err
+	}
+
+	// re-encode that as a single YAML string
+	singleString, err := goYaml.Marshal(singleValue)
+	if err != nil {
+		return err
+	}
+
+	// decode that using ghodss/yaml
+	err = ghodssYaml.Unmarshal(singleString, &result)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/yaml/decoder_test.go
+++ b/yaml/decoder_test.go
@@ -1,0 +1,66 @@
+package yaml
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/renstrom/dedent"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecoder(t *testing.T) {
+	doc := dedent.Dedent(`
+		# a comment
+		---
+		document: 1
+		... # document suffix
+		---
+		["document", "2"]
+		---
+		document 3
+		---
+		4  # just an integer`)
+
+	dec := NewDecoder(bytes.NewReader([]byte(doc)))
+	var decoded interface{}
+
+	err := dec.Decode(&decoded)
+	if err != nil {
+		t.Errorf("%s", err)
+		return
+	}
+	require.Equal(t, fmt.Sprintf("%#v", decoded), "map[string]interface {}{\"document\":1}")
+
+	err = dec.Decode(&decoded)
+	if err != nil {
+		t.Errorf("%s", err)
+		return
+	}
+	require.Equal(t, fmt.Sprintf("%#v", decoded), "[]interface {}{\"document\", \"2\"}")
+
+	err = dec.Decode(&decoded)
+	if err != nil {
+		t.Errorf("%s", err)
+		return
+	}
+	require.Equal(t, fmt.Sprintf("%#v", decoded), "\"document 3\"")
+
+	err = dec.Decode(&decoded)
+	if err != nil {
+		t.Errorf("%s", err)
+		return
+	}
+	require.Equal(t, fmt.Sprintf("%#v", decoded), "4")
+
+	err = dec.Decode(&decoded)
+	if err == nil {
+		t.Errorf("expected io.EOF, got %#v", decoded)
+		return
+	}
+	if err != io.EOF {
+		t.Errorf("%s", err)
+		return
+	}
+}


### PR DESCRIPTION
So the process is:
 * ingest bytestream
 * produce go-yaml YAML data structures
 * encode to YAML
 * ghodss decode
   * decode to go-YAML data structures
   * convert to JSON data structures
   * encode in JSON
   * decode to JSON data structures
 * encode to JSON or YAML depending on the `format` argument

But, it works!